### PR TITLE
Fix start script and window loading

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ function createWindow () {
         resizable: false
     });
 
-    mainWindow.loadURL(path.join(__dirname, 'src/html/index.html'));
+    mainWindow.loadFile(path.join(__dirname, 'src/html/index.html'));
 
     mainWindow.on('closed', () => {
         mainWindow = null

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node ."
+    "start": "electron ."
   },
   "author": "Pierce Harriz",
   "license": "ISC",


### PR DESCRIPTION
**Changes start script in package.json**
- Electron uses `electron .` not `node .` to initialize application

**Changes the way the browser window loads your file**
- BrowserWindows have two separate methods for loading websites and loading local files

